### PR TITLE
smallfix on SCSS in DefaultSidebar

### DIFF
--- a/packages/klb-vue/src/components/ui/DefaultSidebar.vue
+++ b/packages/klb-vue/src/components/ui/DefaultSidebar.vue
@@ -77,6 +77,9 @@ const isOpen = useStorage(`isOpenSidebar-${props.id}`, true);
     @apply relative flex w-full items-center py-3 px-3 font-semibold text-sm border-l-[.4rem] border-l-transparent;
     @apply text-fv-neutral-600 hover:bg-fv-neutral-200/[.3] focus:bg-fv-neutral-200/[.3] hover:text-fv-primary-600;
     @apply dark:text-fv-neutral-300 dark:hover:bg-fv-neutral-700/[.3] dark:focus:bg-fv-neutral-700/[.3] dark:hover:text-fv-primary-400;
+
+    transition: all 300ms ease-in-out;
+
     &.fvside-active {
       @apply border-l-fv-primary-500 bg-fv-neutral-200  hover:text-fv-neutral-600 focus:text-fv-neutral-600;
       @apply dark:bg-fv-neutral-700 dark:hover:text-fv-neutral-300 dark:text-fv-neutral-300;
@@ -87,7 +90,6 @@ const isOpen = useStorage(`isOpenSidebar-${props.id}`, true);
     span {
       @apply whitespace-nowrap;
     }
-    transition: all 300ms ease-in-out;
   }
 
   &.fui-sidebar__md {


### PR DESCRIPTION
1 line SCSS fix to avoid the following error: 

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`. More info: https://sass-lang.com/d/mixed-decls
   ╷
22 │ ┌     span {
23 │ │       @apply whitespace-nowrap;
24 │ │     }
   │ └─── nested rule
25 │       transition: all 300ms ease-in-out;
   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
   ╵
in /@fy-/klb-vue/components/ui/DefaultSidebar.vue 25:5
```